### PR TITLE
Porting to Hbase 0.98 cdh 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,8 @@
 
 	<properties>
 		<storm.version>0.8.2</storm.version>
-		<hbase.version>0.94.2-cdh4.2.1</hbase.version>
-		<hadoop.version>2.0.0-cdh4.2.1</hadoop.version>
+		<hbase.version>0.98.1-cdh5.1.0</hbase.version>
+		<hadoop.version>2.3.0-mr1-cdh5.1.0</hadoop.version>
 	</properties>
 
 	<dependencies>
@@ -50,12 +50,12 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hbase</groupId>
-			<artifactId>hbase</artifactId>
+			<artifactId>hbase-client</artifactId>
 			<version>${hbase.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
-			<artifactId>hadoop-common</artifactId>
+			<artifactId>hadoop-client</artifactId>
 			<version>${hadoop.version}</version>
 		</dependency>
 		<dependency>

--- a/src/main/java/backtype/storm/contrib/hbase/utils/TupleTableConfig.java
+++ b/src/main/java/backtype/storm/contrib/hbase/utils/TupleTableConfig.java
@@ -181,7 +181,6 @@ public class TupleTableConfig implements Serializable {
       cell = CellUtil.createCell(inc.getRow(), family, qualifier, cell.getTimestamp(), cell.getTypeByte(),
               Bytes.toBytes(counter + amount));
       cells.set(cellIndex, cell);
-      inc.getFamilyCellMap().put(inc.getRow(), origCells);
     }
   }
 

--- a/src/main/java/backtype/storm/contrib/hbase/utils/TupleTableConfig.java
+++ b/src/main/java/backtype/storm/contrib/hbase/utils/TupleTableConfig.java
@@ -15,8 +15,6 @@ import org.apache.hadoop.hbase.util.Bytes;
 
 import backtype.storm.tuple.Tuple;
 
-import javax.annotation.Nullable;
-
 /**
  * Configuration for Storm {@link Tuple} to HBase serialization.
  */
@@ -165,7 +163,7 @@ public class TupleTableConfig implements Serializable {
 
     int cellIndex = Iterables.indexOf(cells, new Predicate<Cell>() {
       @Override
-      public boolean apply(@Nullable Cell cell) {
+      public boolean apply(Cell cell) {
         if (CellUtil.matchingQualifier(cell, qualifier)) {
           return true;
         }

--- a/src/test/java/backtype/storm/contrib/hbase/utils/test/TestSerialisation.java
+++ b/src/test/java/backtype/storm/contrib/hbase/utils/test/TestSerialisation.java
@@ -19,13 +19,13 @@ public class TestSerialisation {
     i.addColumn(CF, CQ1, 1); // set counter to 1
     i.addColumn(CF, CQ1, 1); // overrides counter, so its still 1
 
-    Assert.assertEquals(1L, (long) i.getFamilyMap().get(CF).get(CQ1));
+    Assert.assertEquals(1L, (long) i.getFamilyMapOfLongs().get(CF).get(CQ1));
 
     TupleTableConfig.addIncrement(i, CF, CQ1, 2L); // increment counter by 2
     TupleTableConfig.addIncrement(i, CF, CQ2, 2L); // increment different
                                                    // qualifier by 2
 
-    Assert.assertEquals(3L, (long) i.getFamilyMap().get(CF).get(CQ1));
-    Assert.assertEquals(2L, (long) i.getFamilyMap().get(CF).get(CQ2));
+    Assert.assertEquals(3L, (long) i.getFamilyMapOfLongs().get(CF).get(CQ1));
+    Assert.assertEquals(2L, (long) i.getFamilyMapOfLongs().get(CF).get(CQ2));
   }
 }


### PR DESCRIPTION
We're moving to HBase 0.98 and would like to contribute these changes back. Specifically we're using CDH 5.2 (when it comes out), but here I've made the changes to use CDH 5.1 (same HBase version anyway, 0.98)

I suppose a different branch should be kept for 0.98 vs 0.94 compatibility.
